### PR TITLE
fixed top margin for 'role' banner above logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,7 +166,7 @@
     <header class="w3-display-container w3-content w3-wide" style="max-width:1500px;" id="home">
         <img class="" src="https://raw.githubusercontent.com/km594/krispinmoutia/master/pics/logo-2530x2530.png"
             alt="Architecture" width="1500" height="800" style="object-fit: contain;max-width: 100%" loading="lazy">
-        <div class="w3-display-topmiddle w3-margin-top w3-center" style="margin-top: 5vh !important;">
+        <div class="w3-display-topmiddle w3-margin-top w3-center" style="margin-top: max(5vh, 55px) !important;">
             <h1 class="w3-xxlarge w3-text-white"><span
                     class="w3-padding w3-bar-block w3-black w3-opacity-min w3-hide-small w3-hide-medium"><b class="">Hi,
                         I'm Krispin <br></b></span><span class="w3-hide-small w3-text-light-grey w3-xlarge"


### PR DESCRIPTION
adding fixed min margin of 55px (height of navbar) instead of solely using viewport height to set margin.