### PR TITLE
Add fix for Power BI Publish to Web downtime

### DIFF
--- a/index.html
+++ b/index.html
@@ -370,7 +370,7 @@
                     <div class="w3-display-container">
                         <!-- <div class="w3-display-topleft w3-black w3-padding">Campbelltown Businesses</div> -->
                         <iframe title="campbelltown-business-data - Page 1" width="100%" height="100%"
-                            src="https://app.powerbi.com/view?r=eyJrIjoiNmJlZjRjMjYtMjM4OS00YzAwLTkyYmQtYjllMGZlNGQ2OGU1IiwidCI6ImRkNGI0YmI2LWIyMzctNDAyYi1hMDJjLWM0ZTk1N2M5MDY0ZSJ9"
+                            src="https://app.powerbi.com/view?r=eyJrIjoiNmJlZjRjMjYtMjM4OS00YzAwLTkyYmQtYjllMGZlNGQ2OGU1IiwidCI6ImRkNGI0YmI2LWIyMzctNDAyYi1hMDJjLWM0ZTk1N2M5MDY0ZSJ9&angularOnlyReportEmbed=false"
                             frameborder="0" allowFullScreen="true" loading="lazy" class="poster-lg">
                         </iframe>
                     </div>
@@ -390,7 +390,7 @@
                     <div class="w3-display-container">
                         <!-- <div class="w3-display-topleft w3-black w3-padding">Registered Engineers</div> -->
                         <iframe title="register-engineering-2020" width="100%" height="100%"
-                            src="https://app.powerbi.com/view?r=eyJrIjoiNmU3MjQ5MGQtYWQyYy00YmM1LTlhZTItOTMzMjY1YjNhNzkwIiwidCI6ImRkNGI0YmI2LWIyMzctNDAyYi1hMDJjLWM0ZTk1N2M5MDY0ZSJ9&pageName=ReportSection"
+                            src="https://app.powerbi.com/view?r=eyJrIjoiNmU3MjQ5MGQtYWQyYy00YmM1LTlhZTItOTMzMjY1YjNhNzkwIiwidCI6ImRkNGI0YmI2LWIyMzctNDAyYi1hMDJjLWM0ZTk1N2M5MDY0ZSJ9&pageName=ReportSection&angularOnlyReportEmbed=false"
                             frameborder="0" allowFullScreen="true" loading="lazy" class="poster-lg">
                         </iframe>
                     </div>


### PR DESCRIPTION
Awareness

Power BI customers embedding "Published To Web" reports into a website using the HTML generated, may experience intermittent issues loading visuals. Engineers are working on a fix and expect it to be deployed to all regions by end-of-day 03/12/2022

As a workaround, customers can append "&angularOnlyReportEmbed=false" at the end of src URL in the html code generated in Power BI